### PR TITLE
Refactor: Rename package to ai.wanaku.code.engine.camel and main class to CamelEngineMain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <wanaku.sdk.version>0.1.0-SNAPSHOT</wanaku.sdk.version>
         <camel.version>4.17.0</camel.version>
         <snakeyaml.version>2.0</snakeyaml.version>
-        <project.main.class>ai.wanaku.code.engine.camel.App</project.main.class>
+        <project.main.class>ai.wanaku.code.engine.camel.CamelEngineMain</project.main.class>
         <spotless-maven-plugin.version>3.1.0</spotless-maven-plugin.version>
         <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
     </properties>

--- a/src/main/java/ai/wanaku/code/engine/camel/CamelEngineMain.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/CamelEngineMain.java
@@ -31,8 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
-public class App implements Callable<Integer> {
-    private static final Logger LOG = LoggerFactory.getLogger(App.class);
+public class CamelEngineMain implements Callable<Integer> {
+    private static final Logger LOG = LoggerFactory.getLogger(CamelEngineMain.class);
 
     @CommandLine.Option(
             names = {"-h", "--help"},
@@ -126,7 +126,7 @@ public class App implements Callable<Integer> {
     private String repositories;
 
     public static void main(String[] args) {
-        int exitCode = new CommandLine(new App()).execute(args);
+        int exitCode = new CommandLine(new CamelEngineMain()).execute(args);
 
         System.exit(exitCode);
     }


### PR DESCRIPTION
## Summary
- Renamed package from `ai.wanaku` to `ai.wanaku.code.engine.camel` for better namespace organization
- Renamed main class from `App` to `CamelEngineMain` for improved clarity and descriptiveness
- Updated all configuration files (pom.xml, jreleaser.yml, log4j2.properties) to reflect new package and class names

## Changes
### Package Rename (ai.wanaku → ai.wanaku.code.engine.camel)
- Moved all 20 Java files to new package structure
- Updated package declarations across all files
- Updated internal imports in 7 files
- Modified groupId in pom.xml and jreleaser.yml
- Updated logger configuration in log4j2.properties

### Class Rename (App → CamelEngineMain)
- Renamed `App.java` to `CamelEngineMain.java`
- Updated class declaration and all references
- Updated main class property in pom.xml

## Test plan
- [x] Project compiles successfully with `mvn clean compile`
- [x] Project packages successfully with `mvn package`
- [x] No old package references remain in source code
- [x] Git history preserved for all renamed files
- [ ] Verify application starts correctly
- [ ] Confirm logging works with new package name
