### PR TITLE
Align dependencies and APIs with upstream SDK 0.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,17 +11,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <slf4j.version>2.0.17</slf4j.version>
-        <log4j.version>2.25.3</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <picocli.version>4.7.7</picocli.version>
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
-        <wanaku.sdk.version>0.1.0-SNAPSHOT</wanaku.sdk.version>
-        <camel.version>4.17.0</camel.version>
+        <wanaku-capabilities-sdk.version>0.1.0</wanaku-capabilities-sdk.version>
+        <camel.version>4.18.1</camel.version>
+        <jackson-databind.version>2.21.2</jackson-databind.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <project.main.class>ai.wanaku.code.engine.camel.CamelEngineMain</project.main.class>
-        <spotless-maven-plugin.version>3.2.1</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
         <maven-failsafe-plugin.version>3.5.5</maven-failsafe-plugin.version>
         <commons-compress.version>1.26.0</commons-compress.version>
-        <junit.version>5.11.0</junit.version>
+        <junit.version>5.14.3</junit.version>
+        <jgit.version>7.6.0.202603022253-r</jgit.version>
+        <palantir-format-version.version>2.71.0</palantir-format-version.version>
     </properties>
 
     <dependencyManagement>
@@ -44,7 +47,7 @@
             <dependency>
                 <groupId>ai.wanaku.sdk</groupId>
                 <artifactId>capabilities-bom</artifactId>
-                <version>${wanaku.sdk.version}</version>
+                <version>${wanaku-capabilities-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -70,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>ai.wanaku.sdk</groupId>
-            <artifactId>capabilities-runtime</artifactId>
+            <artifactId>capabilities-runtimes-common</artifactId>
         </dependency>
         <dependency>
             <groupId>ai.wanaku.sdk</groupId>
@@ -134,7 +137,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>7.5.0.202512021534-r</version>
+            <version>${jgit.version}</version>
         </dependency>
 
         <!-- Apache Commons Compress for tar.bz2 extraction -->
@@ -212,10 +215,21 @@
                     <configuration>
                         <java>
                             <palantirJavaFormat>
-                                <version>2.71.0</version>
+                                <version>${palantir-format-version.version}</version>
                             </palantirJavaFormat>
                             <removeUnusedImports />
                             <formatAnnotations />
+                            <forbidWildcardImports />
+
+                            <excludes>
+                                <exclude>**/*.properties</exclude>
+                                <exclude>**/*.proto</exclude>
+                            </excludes>
+
+                            <importOrder>
+                                <wildcardsLast>true</wildcardsLast>
+                                <order>jakarta|javax,org.w3c|org.xml,java|org|io|,,\#,org.junit|org.mockito|\#org.assertj|\#org.junit|\#org.mockito</order>
+                            </importOrder>
                         </java>
                     </configuration>
                     <executions>

--- a/src/main/java/ai/wanaku/code/engine/camel/CamelEngineMain.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/CamelEngineMain.java
@@ -1,5 +1,15 @@
 package ai.wanaku.code.engine.camel;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.grpc.Grpc;
+import io.grpc.InsecureServerCredentials;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
 import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
 import ai.wanaku.capabilities.sdk.api.types.providers.ServiceType;
@@ -22,16 +32,6 @@ import ai.wanaku.code.engine.camel.grpc.ProvisionBase;
 import ai.wanaku.code.engine.camel.init.Initializer;
 import ai.wanaku.code.engine.camel.init.InitializerFactory;
 import ai.wanaku.code.engine.camel.util.VersionHelper;
-import io.grpc.Grpc;
-import io.grpc.InsecureServerCredentials;
-import io.grpc.Server;
-import io.grpc.ServerBuilder;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.Callable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 public class CamelEngineMain implements Callable<Integer> {

--- a/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
@@ -1,13 +1,13 @@
 package ai.wanaku.code.engine.camel;
 
-import ai.wanaku.code.engine.camel.downloader.ResourceType;
-import ai.wanaku.code.engine.camel.util.WanakuRoutesLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
+import ai.wanaku.code.engine.camel.downloader.ResourceType;
+import ai.wanaku.code.engine.camel.util.WanakuRoutesLoader;
 
 public class WanakuCamelManager {
     private final CamelContext context;

--- a/src/main/java/ai/wanaku/code/engine/camel/codegen/CodeGenDiscoveryCallback.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/codegen/CodeGenDiscoveryCallback.java
@@ -1,12 +1,5 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
-import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
-import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
-import ai.wanaku.code.engine.camel.downloader.DownloaderFactory;
-import ai.wanaku.code.engine.camel.downloader.ResourceRefs;
-import ai.wanaku.code.engine.camel.downloader.ResourceType;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,6 +9,13 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
+import ai.wanaku.code.engine.camel.downloader.DownloaderFactory;
+import ai.wanaku.code.engine.camel.downloader.ResourceRefs;
+import ai.wanaku.code.engine.camel.downloader.ResourceType;
 
 /**
  * Discovery callback that initializes and registers code generation tools.

--- a/src/main/java/ai/wanaku/code/engine/camel/codegen/CodeGenToolRegistrar.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/codegen/CodeGenToolRegistrar.java
@@ -1,12 +1,5 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import ai.wanaku.capabilities.sdk.api.types.InputSchema;
-import ai.wanaku.capabilities.sdk.api.types.Property;
-import ai.wanaku.capabilities.sdk.api.types.ToolReference;
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
-import ai.wanaku.code.engine.camel.codegen.tools.GenerateOrchestrationTool;
-import ai.wanaku.code.engine.camel.codegen.tools.ReadKameletTool;
-import ai.wanaku.code.engine.camel.codegen.tools.SearchServicesTool;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -14,6 +7,13 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.types.InputSchema;
+import ai.wanaku.capabilities.sdk.api.types.Property;
+import ai.wanaku.capabilities.sdk.api.types.ToolReference;
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
+import ai.wanaku.code.engine.camel.codegen.tools.GenerateOrchestrationTool;
+import ai.wanaku.code.engine.camel.codegen.tools.ReadKameletTool;
+import ai.wanaku.code.engine.camel.codegen.tools.SearchServicesTool;
 
 /**
  * Registers and deregisters code generation tools with Wanaku.

--- a/src/main/java/ai/wanaku/code/engine/camel/codegen/CodeGenToolService.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/codegen/CodeGenToolService.java
@@ -1,12 +1,12 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import ai.wanaku.code.engine.camel.codegen.tools.GenerateOrchestrationTool;
-import ai.wanaku.code.engine.camel.codegen.tools.ReadKameletTool;
-import ai.wanaku.code.engine.camel.codegen.tools.SearchServicesTool;
 import java.net.URI;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.code.engine.camel.codegen.tools.GenerateOrchestrationTool;
+import ai.wanaku.code.engine.camel.codegen.tools.ReadKameletTool;
+import ai.wanaku.code.engine.camel.codegen.tools.SearchServicesTool;
 
 /**
  * Service that handles code generation tool invocations.

--- a/src/main/java/ai/wanaku/code/engine/camel/codegen/tools/GenerateOrchestrationTool.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/codegen/tools/GenerateOrchestrationTool.java
@@ -1,9 +1,9 @@
 package ai.wanaku.code.engine.camel.codegen.tools;
 
-import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 
 /**
  * Tool that returns the orchestration template for code generation.

--- a/src/main/java/ai/wanaku/code/engine/camel/codegen/tools/ReadKameletTool.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/codegen/tools/ReadKameletTool.java
@@ -1,9 +1,9 @@
 package ai.wanaku.code.engine.camel.codegen.tools;
 
-import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 
 /**
  * Tool that reads the content of a Kamelet by name.

--- a/src/main/java/ai/wanaku/code/engine/camel/codegen/tools/SearchServicesTool.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/codegen/tools/SearchServicesTool.java
@@ -1,10 +1,10 @@
 package ai.wanaku.code.engine.camel.codegen.tools;
 
-import ai.wanaku.code.engine.camel.codegen.CodeGenConfig;
-import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.code.engine.camel.codegen.CodeGenConfig;
+import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 
 /**
  * Tool that searches for available services (Kamelets) in the code generation package.

--- a/src/main/java/ai/wanaku/code/engine/camel/downloader/DataStoreDownloader.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/downloader/DataStoreDownloader.java
@@ -1,8 +1,5 @@
 package ai.wanaku.code.engine.camel.downloader;
 
-import ai.wanaku.capabilities.sdk.api.types.DataStore;
-import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -11,6 +8,9 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 
 public class DataStoreDownloader implements Downloader {
     private static final Logger LOG = LoggerFactory.getLogger(DataStoreDownloader.class);

--- a/src/main/java/ai/wanaku/code/engine/camel/downloader/DownloaderFactory.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/downloader/DownloaderFactory.java
@@ -1,10 +1,10 @@
 package ai.wanaku.code.engine.camel.downloader;
 
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 import java.net.URI;
 import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 
 /**
  * Factory for creating downloader instances based on URI scheme.

--- a/src/main/java/ai/wanaku/code/engine/camel/downloader/ResourceDownloaderCallback.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/downloader/ResourceDownloaderCallback.java
@@ -1,9 +1,5 @@
 package ai.wanaku.code.engine.camel.downloader;
 
-import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
-import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
-import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
-import ai.wanaku.capabilities.sdk.common.exceptions.WanakuWebException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -12,6 +8,10 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.discovery.DiscoveryCallback;
+import ai.wanaku.capabilities.sdk.api.discovery.RegistrationManager;
+import ai.wanaku.capabilities.sdk.api.types.providers.ServiceTarget;
+import ai.wanaku.capabilities.sdk.common.exceptions.WanakuWebException;
 
 public class ResourceDownloaderCallback implements DiscoveryCallback {
     private static final Logger LOG = LoggerFactory.getLogger(ResourceDownloaderCallback.class);

--- a/src/main/java/ai/wanaku/code/engine/camel/downloader/TarBz2Downloader.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/downloader/TarBz2Downloader.java
@@ -1,9 +1,5 @@
 package ai.wanaku.code.engine.camel.downloader;
 
-import ai.wanaku.capabilities.sdk.api.types.DataStore;
-import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
-import ai.wanaku.code.engine.camel.util.ArchiveExtractor;
 import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.nio.file.Files;
@@ -13,6 +9,10 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.capabilities.sdk.api.types.DataStore;
+import ai.wanaku.capabilities.sdk.api.types.WanakuResponse;
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
+import ai.wanaku.code.engine.camel.util.ArchiveExtractor;
 
 /**
  * Downloads and extracts tar.bz2 archives from the Wanaku data store.

--- a/src/main/java/ai/wanaku/code/engine/camel/grpc/CodeExecutorService.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/grpc/CodeExecutorService.java
@@ -1,20 +1,22 @@
 package ai.wanaku.code.engine.camel.grpc;
 
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
-import ai.wanaku.code.engine.camel.WanakuCamelManager;
-import ai.wanaku.core.exchange.CodeExecutionReply;
-import ai.wanaku.core.exchange.CodeExecutionRequest;
-import ai.wanaku.core.exchange.CodeExecutorGrpc;
-import ai.wanaku.core.exchange.ExecutionStatus;
-import ai.wanaku.core.exchange.OutputType;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import org.apache.camel.CamelContext;
 import org.apache.camel.ProducerTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.grpc.stub.StreamObserver;
+import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
+import ai.wanaku.code.engine.camel.WanakuCamelManager;
+import ai.wanaku.core.exchange.v1.CodeExecutionReply;
+import ai.wanaku.core.exchange.v1.CodeExecutionRequest;
+import ai.wanaku.core.exchange.v1.CodeExecutorGrpc;
+import ai.wanaku.core.exchange.v1.ExecutionStatus;
+import ai.wanaku.core.exchange.v1.OutputType;
+import com.google.protobuf.Timestamp;
 
 public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CodeExecutorService.class);
@@ -29,6 +31,14 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
         this.defaultRepositories = defaultRepositories;
     }
 
+    private static Timestamp now() {
+        Instant instant = Instant.now();
+        return Timestamp.newBuilder()
+                .setSeconds(instant.getEpochSecond())
+                .setNanos(instant.getNano())
+                .build();
+    }
+
     @Override
     public void executeCode(CodeExecutionRequest request, StreamObserver<CodeExecutionReply> responseObserver) {
         LOG.info("Received code execution request for URI: {}", request.getUri());
@@ -41,14 +51,11 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
         WanakuCamelManager camelManager = null;
 
         try {
-            long timestamp = System.currentTimeMillis();
-
             responseObserver.onNext(CodeExecutionReply.newBuilder()
-                    .setIsError(false)
                     .addContent("Creating workspace")
-                    .setOutputType(OutputType.STATUS)
-                    .setStatus(ExecutionStatus.PENDING)
-                    .setTimestamp(timestamp)
+                    .setOutputType(OutputType.OUTPUT_TYPE_STATUS)
+                    .setStatus(ExecutionStatus.EXECUTION_STATUS_PENDING)
+                    .setTimestamp(now())
                     .build());
 
             // 0. Validate request has code
@@ -76,11 +83,10 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
             }
 
             responseObserver.onNext(CodeExecutionReply.newBuilder()
-                    .setIsError(false)
                     .addContent("Routes written to workspace")
-                    .setOutputType(OutputType.STATUS)
-                    .setStatus(ExecutionStatus.PENDING)
-                    .setTimestamp(System.currentTimeMillis())
+                    .setOutputType(OutputType.OUTPUT_TYPE_STATUS)
+                    .setStatus(ExecutionStatus.EXECUTION_STATUS_PENDING)
+                    .setTimestamp(now())
                     .build());
 
             // 3. Extract dependencies from arguments map
@@ -93,11 +99,10 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
 
             // 5. Create WanakuCamelManager and load routes
             responseObserver.onNext(CodeExecutionReply.newBuilder()
-                    .setIsError(false)
                     .addContent("Initializing Camel context and loading routes")
-                    .setOutputType(OutputType.STATUS)
-                    .setStatus(ExecutionStatus.RUNNING)
-                    .setTimestamp(System.currentTimeMillis())
+                    .setOutputType(OutputType.OUTPUT_TYPE_STATUS)
+                    .setStatus(ExecutionStatus.EXECUTION_STATUS_RUNNING)
+                    .setTimestamp(now())
                     .build());
 
             LOG.info("Starting Camel Context");
@@ -105,20 +110,18 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
             LOG.info("CamelContext started with routes");
 
             responseObserver.onNext(CodeExecutionReply.newBuilder()
-                    .setIsError(false)
                     .addContent("Camel routes loaded and context started")
-                    .setOutputType(OutputType.STATUS)
-                    .setStatus(ExecutionStatus.RUNNING)
-                    .setTimestamp(System.currentTimeMillis())
+                    .setOutputType(OutputType.OUTPUT_TYPE_STATUS)
+                    .setStatus(ExecutionStatus.EXECUTION_STATUS_RUNNING)
+                    .setTimestamp(now())
                     .build());
 
             // 6. Stream execution status - the routes are already running in the CamelContext
             responseObserver.onNext(CodeExecutionReply.newBuilder()
-                    .setIsError(false)
                     .addContent("Routes are now executing")
-                    .setOutputType(OutputType.STATUS)
-                    .setStatus(ExecutionStatus.RUNNING)
-                    .setTimestamp(System.currentTimeMillis())
+                    .setOutputType(OutputType.OUTPUT_TYPE_STATUS)
+                    .setStatus(ExecutionStatus.EXECUTION_STATUS_RUNNING)
+                    .setTimestamp(now())
                     .build());
 
             final CamelContext camelContext = camelManager.getCamelContext();
@@ -129,20 +132,18 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
                 final String reply = producerTemplate.requestBody("direct:start", body, String.class);
 
                 responseObserver.onNext(CodeExecutionReply.newBuilder()
-                        .setIsError(false)
-                        .setOutputType(OutputType.STDOUT)
-                        .setStatus(ExecutionStatus.COMPLETED)
+                        .setOutputType(OutputType.OUTPUT_TYPE_STDOUT)
+                        .setStatus(ExecutionStatus.EXECUTION_STATUS_COMPLETED)
                         .addContent(reply.toString())
                         .build());
 
                 // 8. Send completion status
                 responseObserver.onNext(CodeExecutionReply.newBuilder()
-                        .setIsError(false)
                         .addContent("Execution completed successfully")
-                        .setOutputType(OutputType.COMPLETION)
-                        .setStatus(ExecutionStatus.COMPLETED)
+                        .setOutputType(OutputType.OUTPUT_TYPE_COMPLETION)
+                        .setStatus(ExecutionStatus.EXECUTION_STATUS_COMPLETED)
                         .setExitCode(0)
-                        .setTimestamp(System.currentTimeMillis())
+                        .setTimestamp(now())
                         .build());
 
                 responseObserver.onCompleted();
@@ -155,12 +156,11 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
         } catch (Exception e) {
             LOG.error("Error during code execution", e);
             responseObserver.onNext(CodeExecutionReply.newBuilder()
-                    .setIsError(true)
                     .addContent("Execution failed: " + e.getMessage())
-                    .setOutputType(OutputType.STDERR)
-                    .setStatus(ExecutionStatus.FAILED)
+                    .setOutputType(OutputType.OUTPUT_TYPE_STDERR)
+                    .setStatus(ExecutionStatus.EXECUTION_STATUS_FAILED)
                     .setExitCode(1)
-                    .setTimestamp(System.currentTimeMillis())
+                    .setTimestamp(now())
                     .build());
             responseObserver.onCompleted();
         } finally {
@@ -210,12 +210,11 @@ public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
         }
 
         responseObserver.onNext(CodeExecutionReply.newBuilder()
-                .setIsError(true)
                 .addContent(String.format("Unable to invoke tool: %s", e.getMessage()))
                 .setExitCode(2)
-                .setTimestamp(System.currentTimeMillis())
-                .setOutputType(OutputType.STDERR)
-                .setStatus(ExecutionStatus.FAILED)
+                .setTimestamp(now())
+                .setOutputType(OutputType.OUTPUT_TYPE_STDERR)
+                .setStatus(ExecutionStatus.EXECUTION_STATUS_FAILED)
                 .build());
     }
 }

--- a/src/main/java/ai/wanaku/code/engine/camel/grpc/CodeGenToolInvokerService.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/grpc/CodeGenToolInvokerService.java
@@ -1,15 +1,16 @@
 package ai.wanaku.code.engine.camel.grpc;
 
-import ai.wanaku.code.engine.camel.codegen.CodeGenToolService;
-import ai.wanaku.core.exchange.ToolInvokeReply;
-import ai.wanaku.core.exchange.ToolInvokeRequest;
-import ai.wanaku.core.exchange.ToolInvokerGrpc;
-import io.grpc.stub.StreamObserver;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import ai.wanaku.code.engine.camel.codegen.CodeGenToolService;
+import ai.wanaku.core.exchange.v1.ToolInvokeReply;
+import ai.wanaku.core.exchange.v1.ToolInvokeRequest;
+import ai.wanaku.core.exchange.v1.ToolInvokerGrpc;
 
 /**
  * gRPC service for invoking code generation tools.
@@ -33,11 +34,9 @@ public class CodeGenToolInvokerService extends ToolInvokerGrpc.ToolInvokerImplBa
 
         if (!codeGenToolService.isReady()) {
             LOG.warn("Code generation tool service is not ready");
-            responseObserver.onNext(ToolInvokeReply.newBuilder()
-                    .setIsError(true)
-                    .addAllContent(List.of("Code generation tool service is not ready"))
-                    .build());
-            responseObserver.onCompleted();
+            responseObserver.onError(Status.UNAVAILABLE
+                    .withDescription("Code generation tool service is not ready")
+                    .asRuntimeException());
             return;
         }
 
@@ -49,25 +48,20 @@ public class CodeGenToolInvokerService extends ToolInvokerGrpc.ToolInvokerImplBa
 
             if (result.isError()) {
                 LOG.warn("Tool invocation failed: {}", result.getError());
-                responseObserver.onNext(ToolInvokeReply.newBuilder()
-                        .setIsError(true)
-                        .addAllContent(List.of(result.getError()))
-                        .build());
+                responseObserver.onError(
+                        Status.INTERNAL.withDescription(result.getError()).asRuntimeException());
             } else {
                 LOG.debug("Tool invocation succeeded");
                 responseObserver.onNext(ToolInvokeReply.newBuilder()
-                        .setIsError(false)
                         .addAllContent(List.of(result.getContent()))
                         .build());
+                responseObserver.onCompleted();
             }
         } catch (Exception e) {
             LOG.error("Error invoking tool: {}", e.getMessage(), e);
-            responseObserver.onNext(ToolInvokeReply.newBuilder()
-                    .setIsError(true)
-                    .addAllContent(List.of("Tool invocation error: " + e.getMessage()))
-                    .build());
-        } finally {
-            responseObserver.onCompleted();
+            responseObserver.onError(Status.INTERNAL
+                    .withDescription("Tool invocation error: " + e.getMessage())
+                    .asRuntimeException());
         }
     }
 }

--- a/src/main/java/ai/wanaku/code/engine/camel/grpc/ProvisionBase.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/grpc/ProvisionBase.java
@@ -1,15 +1,15 @@
 package ai.wanaku.code.engine.camel.grpc;
 
+import java.util.Map;
+import io.grpc.stub.StreamObserver;
 import ai.wanaku.capabilities.sdk.config.provider.api.ConfigProvisioner;
 import ai.wanaku.capabilities.sdk.config.provider.api.ProvisionedConfig;
 import ai.wanaku.capabilities.sdk.runtime.provisioners.FileProvisionerLoader;
 import ai.wanaku.capabilities.sdk.util.ProvisioningHelper;
-import ai.wanaku.core.exchange.PropertySchema;
-import ai.wanaku.core.exchange.ProvisionReply;
-import ai.wanaku.core.exchange.ProvisionRequest;
-import ai.wanaku.core.exchange.ProvisionerGrpc;
-import io.grpc.stub.StreamObserver;
-import java.util.Map;
+import ai.wanaku.core.exchange.v1.PropertySchema;
+import ai.wanaku.core.exchange.v1.ProvisionReply;
+import ai.wanaku.core.exchange.v1.ProvisionRequest;
+import ai.wanaku.core.exchange.v1.ProvisionerGrpc;
 
 public class ProvisionBase extends ProvisionerGrpc.ProvisionerImplBase {
 

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenConfigTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenConfigTest.java
@@ -1,14 +1,16 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Properties;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for CodeGenConfig.

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenDiscoveryCallbackTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenDiscoveryCallbackTest.java
@@ -1,13 +1,13 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Unit tests for CodeGenDiscoveryCallback local directory support.

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenResourceLoaderTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenResourceLoaderTest.java
@@ -1,14 +1,18 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for CodeGenResourceLoader.

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenToolServiceTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/CodeGenToolServiceTest.java
@@ -1,15 +1,17 @@
 package ai.wanaku.code.engine.camel.codegen;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for CodeGenToolService.

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/tools/GenerateOrchestrationToolTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/tools/GenerateOrchestrationToolTest.java
@@ -1,14 +1,17 @@
 package ai.wanaku.code.engine.camel.codegen.tools;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for GenerateOrchestrationTool.

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/tools/ReadKameletToolTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/tools/ReadKameletToolTest.java
@@ -1,14 +1,16 @@
 package ai.wanaku.code.engine.camel.codegen.tools;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for ReadKameletTool.

--- a/src/test/java/ai/wanaku/code/engine/camel/codegen/tools/SearchServicesToolTest.java
+++ b/src/test/java/ai/wanaku/code/engine/camel/codegen/tools/SearchServicesToolTest.java
@@ -1,14 +1,15 @@
 package ai.wanaku.code.engine.camel.codegen.tools;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import ai.wanaku.code.engine.camel.codegen.CodeGenResourceLoader;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for SearchServicesTool.


### PR DESCRIPTION
## Summary
- Update all dependency versions to match camel-core-downstream-service (Camel 4.18.1, SDK 0.1.0, Log4j 2.25.4, JUnit 5.14.3, JGit 7.6, Spotless 3.4.0)
- Migrate gRPC exchange package from `ai.wanaku.core.exchange` to `ai.wanaku.core.exchange.v1` with updated proto conventions (prefixed enum values, `google.protobuf.Timestamp`, removed reserved `isError` field)
- Rename `capabilities-runtime` artifact to `capabilities-runtimes-common`
- Align Spotless config with downstream (forbidWildcardImports, importOrder, excludes)

## Test plan
- [x] `mvn clean verify` passes (54 tests, 0 failures)
- [x] Spotless formatting check passes
- [x] All gRPC services compile with new proto v1 API