### PR TITLE
chore: fix broken admonition syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The Camel Code Execution Engine (CCE) serves two primary functions:
 - **Git Initialization**: Optional repository cloning at startup
 - **Multi-platform Deployment**: Local, Docker, Kubernetes/OpenShift
 
-> [NOTE]
-> The MCP tools are not YET functional. The agent MUST provide and the execution workflow.
+> [!NOTE]
+> The MCP tools are not yet functional. The agent must provide the data and the execution workflow.
 
 ## Quick Start
 


### PR DESCRIPTION
Fix the note admonition to use GitHub Markdown syntax ([!NOTE] instead of [NOTE]) and correct the incomplete sentence.