### PR TITLE
chore: align Wanaku SDK to 0.1.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         </dependency>
         <dependency>
             <groupId>ai.wanaku.sdk</groupId>
-            <artifactId>capabilities-runtime-camel-common</artifactId>
+            <artifactId>capabilities-runtimes-camel-common</artifactId>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <log4j.version>2.25.4</log4j.version>
         <picocli.version>4.7.7</picocli.version>
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
-        <wanaku-capabilities-sdk.version>0.1.0</wanaku-capabilities-sdk.version>
+        <wanaku-capabilities-sdk.version>0.1.1-SNAPSHOT</wanaku-capabilities-sdk.version>
         <camel.version>4.18.1</camel.version>
         <jackson-databind.version>2.21.2</jackson-databind.version>
         <snakeyaml.version>2.6</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
             <groupId>ai.wanaku.sdk</groupId>
             <artifactId>capabilities-runtimes-camel-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ai.wanaku.sdk</groupId>
+            <artifactId>capabilities-maven-downloader</artifactId>
+        </dependency>
 
 
         <dependency>

--- a/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
@@ -3,50 +3,78 @@ package ai.wanaku.code.engine.camel;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ai.wanaku.capabilities.sdk.maven.GAV;
+import ai.wanaku.capabilities.sdk.maven.WanakuMavenDownloader;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
 import ai.wanaku.capabilities.sdk.runtime.camel.util.WanakuRoutesLoader;
 
 public class WanakuCamelManager {
+    private static final Logger LOG = LoggerFactory.getLogger(WanakuCamelManager.class);
+
     private final CamelContext context;
     private final String routesPath;
-    private final String dependenciesList;
-    private final String repositoriesList;
+    private List<GAV> gavs = new ArrayList<>();
 
     public WanakuCamelManager(Map<ResourceType, Path> downloadedResources, String repositoriesList) throws Exception {
-        this.repositoriesList = repositoriesList;
-        context = new DefaultCamelContext();
-
         this.routesPath = downloadedResources.get(ResourceType.ROUTES_REF).toString();
         if (downloadedResources.containsKey(ResourceType.DEPENDENCY_REF)) {
             String dependenciesPath =
                     downloadedResources.get(ResourceType.DEPENDENCY_REF).toString();
             try {
-                this.dependenciesList = Files.readString(Path.of(dependenciesPath));
+                final List<String> depLines = Files.readAllLines(Path.of(dependenciesPath));
+                this.gavs = depLines.stream()
+                        .filter(l -> !l.startsWith("#"))
+                        .map(GAV::parse)
+                        .collect(Collectors.toList());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        } else {
-            this.dependenciesList = null;
         }
 
+        WanakuMavenDownloader mavenDownloader = new WanakuMavenDownloader(WanakuCamelManager.class.getClassLoader());
+        mavenDownloader.download(gavs);
+
+        context = new DefaultCamelContext();
+        context.setApplicationContextClassLoader(mavenDownloader.getClassLoader());
         loadRoutes();
     }
 
     public WanakuCamelManager(Path routesPath, String dependenciesList, String repositoriesList) throws Exception {
-        this.context = new DefaultCamelContext();
         this.routesPath = routesPath.toString();
-        this.dependenciesList = dependenciesList;
-        this.repositoriesList = repositoriesList;
+
+        if (dependenciesList != null && !dependenciesList.isBlank()) {
+            this.gavs = Arrays.stream(dependenciesList.split("[,\\n]"))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .filter(s -> !s.startsWith("#"))
+                    .map(GAV::parse)
+                    .collect(Collectors.toList());
+        }
+
+        WanakuMavenDownloader mavenDownloader = new WanakuMavenDownloader(WanakuCamelManager.class.getClassLoader());
+        mavenDownloader.download(gavs);
+
+        this.context = new DefaultCamelContext();
+        context.setApplicationContextClassLoader(mavenDownloader.getClassLoader());
         loadRoutes();
     }
 
     private void loadRoutes() throws Exception {
-        WanakuRoutesLoader routesLoader = new WanakuRoutesLoader(dependenciesList, repositoriesList);
+        WanakuRoutesLoader routesLoader = new WanakuRoutesLoader();
 
-        String routeFileUrl = String.format("file://%s", routesPath);
+        String routeFileUrl = Path.of(routesPath).toUri().toString();
         routesLoader.loadRoute(context, routeFileUrl);
         context.start();
 


### PR DESCRIPTION
Align the wanaku-capabilities-sdk dependency to 0.1.1-SNAPSHOT to track upstream SDK development ahead of the 0.1.1 release.