### PR TITLE
chore: use maven.compiler.release instead of source/target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,7 @@
     <version>0.1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <slf4j.version>2.0.18</slf4j.version>


### PR DESCRIPTION
## Summary
- Replaces `maven.compiler.source` and `maven.compiler.target` with `maven.compiler.release` in pom.xml
- Eliminates the compiler warning about `--release 21` being recommended over `-source 21 -target 21`

## Test plan
- [x] `mvn verify` passes
- [x] Compiler warning is no longer emitted