### PR TITLE
chore: add SCM configuration for maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
         </dependencies>
     </dependencyManagement>
 
+    <scm>
+        <connection>scm:git:https://github.com/wanaku-ai/camel-code-execution-engine.git</connection>
+        <developerConnection>scm:git:git@github.com:wanaku-ai/camel-code-execution-engine.git</developerConnection>
+        <url>https://github.com/wanaku-ai/camel-code-execution-engine</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>ai.wanaku.sdk</groupId>


### PR DESCRIPTION
Add the <scm> section to pom.xml so the maven-release-plugin can properly create release tags. Without this, the release workflow (release.yml) would fail when running release:prepare.