### PR TITLE
chore: add markdownlint CI and fix existing violations

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown Lint
+
+on:
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "docs/**/*.md"
+      - "*.md"
+      - ".markdownlint-cli2.yaml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DavidAnson/markdownlint-cli2-action@v19

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,23 @@
+config:
+  MD004:
+    style: "dash"
+  MD013: false
+  MD024:
+    siblings_only: true
+  MD025: false
+  MD033: false
+  MD036: false
+  MD060: false
+
+globs:
+  - "docs/**/*.md"
+  - "*.md"
+
+ignores:
+  - ".oss-ai-helper-rules/**"
+  - ".claude/**"
+  - ".bob/**"
+  - ".specify/**"
+  - "specs/**"
+  - "CLAUDE.md"
+  - "target/**"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Camel Code Execution Engine (CCE) serves two primary functions:
 
 ## Architecture
 
-```
+```text
 ┌─────────────────┐     ┌─────────────────────┐     ┌──────────────────┐
 │    AI Agent     │────▶│  Wanaku MCP Router  │────▶│  Code Execution  │
 │                 │     │                     │     │     Engine       │
@@ -101,7 +101,7 @@ Once started, the service registers with the Wanaku router and exposes its tools
 
 The `--codegen-package` must point to a directory or archive containing:
 
-```
+```text
 package/
 ├── config.properties          # Service list configuration
 ├── kamelets/                  # Kamelet YAML definitions
@@ -112,6 +112,7 @@ package/
 ```
 
 **config.properties** format:
+
 ```properties
 available.services=kamelet:service1,kamelet:service2
 search.tool.description=Custom description for search tool

--- a/docs/codegen-tools.md
+++ b/docs/codegen-tools.md
@@ -42,7 +42,7 @@ The `--codegen-package` option accepts two formats:
 
 The code generation package must have the following structure:
 
-```
+```text
 my-package/
 ├── config.properties      # Required: Configuration file
 ├── kamelets/              # Required: Directory containing Kamelet YAML files
@@ -96,7 +96,7 @@ The `templates/orchestration.txt` file contains the template returned by the `ge
 
 Tools are registered with Wanaku using the service name as the URI scheme:
 
-```
+```text
 <service-name>://searchServicesTool
 <service-name>://readKamelet
 <service-name>://generateOrchestrationCode
@@ -104,7 +104,7 @@ Tools are registered with Wanaku using the service name as the URI scheme:
 
 For example, with `--name code-execution-engine`:
 
-```
+```text
 code-execution-engine://searchServicesTool
 code-execution-engine://readKamelet
 code-execution-engine://generateOrchestrationCode
@@ -119,7 +119,8 @@ Returns a formatted list of available services with context explaining how to us
 **Parameters:** None
 
 **Response:**
-```
+
+```text
 # Context
 - The list below contains Kamelets that can be used to assemble the orchestration.
 - A Kamelet is a snippet for a Camel route.


### PR DESCRIPTION
## Summary

- Add `markdownlint-cli2` configuration (`.markdownlint-cli2.yaml`) with pragmatic rule settings: disable line-length, inline HTML, table-column-style, and emphasis-as-heading rules; set dash list style
- Add GitHub Actions workflow (`.github/workflows/markdown-lint.yml`) that runs on PRs to `main` when documentation files change
- Fix all existing markdown violations (missing fenced code block languages, blank lines around fences) so the CI gate passes from day one

## Test plan

- [ ] Verify `npx markdownlint-cli2` exits with 0 locally
- [ ] Verify the new workflow triggers on a PR that modifies docs
- [ ] Spot-check rendered markdown for formatting regressions