### PR TITLE
chore: fix documentation inaccuracies across README and spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The Camel Code Execution Engine (CCE) serves two primary functions:
 
 - **Dynamic YAML Route Execution**: Execute Camel routes defined in YAML at runtime
 - **Automatic Dependency Resolution**: Downloads Maven dependencies on-the-fly
-- **Code Generation Tools**: Three built-in tools for AI-assisted integration development
+- **Code Generation Tools**: Three MCP-compliant tools for AI-assisted integration development
   - `searchServicesTool` - Lists available Kamelets/integration services
   - `readKamelet` - Returns complete YAML definition of a Kamelet
   - `generateOrchestrationCode` - Returns templates for assembling routes
@@ -42,9 +42,6 @@ The Camel Code Execution Engine (CCE) serves two primary functions:
 - **OAuth2/OIDC Authentication**: Secure service registration
 - **Git Initialization**: Optional repository cloning at startup
 - **Multi-platform Deployment**: Local, Docker, Kubernetes/OpenShift
-
-> [!NOTE]
-> The MCP tools are not yet functional. The agent must provide the data and the execution workflow.
 
 ## Quick Start
 
@@ -95,7 +92,7 @@ Once started, the service registers with the Wanaku router and exposes its tools
 | `--wait-seconds` | 5 | Retry wait time |
 | `--data-dir` | /tmp/cee | Workspace and data directory |
 | `--init-from` | - | Git repository URL to clone at startup |
-| `--repositories` | - | Maven repositories for dependency resolution |
+| `--repositories` | - | Comma-separated list of Maven repository URLs for dependency resolution |
 
 ### Code Generation Package Structure
 
@@ -123,9 +120,10 @@ namespace=optional.namespace
 
 | Scheme | Description |
 |--------|-------------|
-| `datastore://` | Wanaku DataStore access |
-| `datastore-archive://` | Wanaku DataStore with tar.bz2 extraction |
-| `file://` | Local filesystem (absolute paths) |
+| `datastore-archive://` | Wanaku DataStore with tar.bz2 extraction (for code generation packages) |
+| `file://` | Local filesystem path (absolute paths only) |
+
+The `--codegen-package` option accepts either a `datastore-archive://` URI or a local filesystem path.
 
 ## Deployment
 

--- a/docs/codegen-tools.md
+++ b/docs/codegen-tools.md
@@ -101,6 +101,7 @@ Each tool is registered with Wanaku and assigned a unique URI. The URI follows t
 ```
 
 Where:
+
 - `<namespace>` is the optional namespace set in `config.properties` (or empty if not set)
 - `<tool-name>` is one of: `searchServicesTool`, `readKamelet`, `generateOrchestrationCode`
 
@@ -203,7 +204,8 @@ tar -tjf ../codegen-package.tar.bz2
 ```
 
 The archive should contain the files directly at the root level:
-```
+
+```text
 config.properties
 kamelets/
 kamelets/http-source.kamelet.yaml

--- a/docs/codegen-tools.md
+++ b/docs/codegen-tools.md
@@ -94,21 +94,25 @@ The `templates/orchestration.txt` file contains the template returned by the `ge
 
 ## Tool Registration
 
-Tools are registered with Wanaku using the service name as the URI scheme:
+Each tool is registered with Wanaku and assigned a unique URI. The URI follows the pattern:
 
 ```text
-<service-name>://searchServicesTool
-<service-name>://readKamelet
-<service-name>://generateOrchestrationCode
+<namespace>/<tool-name>
 ```
 
-For example, with `--name code-execution-engine`:
+Where:
+- `<namespace>` is the optional namespace set in `config.properties` (or empty if not set)
+- `<tool-name>` is one of: `searchServicesTool`, `readKamelet`, `generateOrchestrationCode`
+
+For example, with `namespace=ai.wanaku.codegen` in config.properties:
 
 ```text
-code-execution-engine://searchServicesTool
-code-execution-engine://readKamelet
-code-execution-engine://generateOrchestrationCode
+ai.wanaku.codegen/searchServicesTool
+ai.wanaku.codegen/readKamelet
+ai.wanaku.codegen/generateOrchestrationCode
 ```
+
+Without a namespace, tools are registered at the root level.
 
 ## Tool Details
 
@@ -188,8 +192,23 @@ java -jar camel-code-execution-engine-app.jar \
 To create a tar.bz2 archive for upload to the data store:
 
 ```bash
-# From the parent directory of your package
-tar -cjf codegen-package.tar.bz2 my-package/
+# Navigate to your package directory
+cd my-package
+
+# Create the archive (note: archive root contains the files directly, not wrapped in a directory)
+tar -cjf ../codegen-package.tar.bz2 config.properties kamelets/ templates/
+
+# Verify the archive structure
+tar -tjf ../codegen-package.tar.bz2
+```
+
+The archive should contain the files directly at the root level:
+```
+config.properties
+kamelets/
+kamelets/http-source.kamelet.yaml
+templates/
+templates/orchestration.txt
 ```
 
 Then upload `codegen-package.tar.bz2` to the Wanaku data store.

--- a/specs/001-codegen-support-tools/contracts/tools-api.md
+++ b/specs/001-codegen-support-tools/contracts/tools-api.md
@@ -11,7 +11,7 @@ These tools are exposed via gRPC through the existing ToolInvoker service. Tools
 
 ### searchServicesTool
 
-**URI**: `codegen://searchServicesTool`
+**URI**: `searchServicesTool` (or `<namespace>/searchServicesTool` if a namespace is configured)
 
 **Description**: (Configurable) Default: "Searches for services to perform the tasks"
 
@@ -50,7 +50,7 @@ kamelet:service3
 
 ### readKamelet
 
-**URI**: `codegen://readKamelet`
+**URI**: `readKamelet` (or `<namespace>/readKamelet` if a namespace is configured)
 
 **Description**: "Reads the content of a Kamelet by name"
 
@@ -108,12 +108,13 @@ spec:
 | Kamelet not found | "Kamelet '{name}' not found" |
 | Invalid Kamelet name | "Invalid Kamelet name: {name}" |
 | Kamelets directory missing | "Code generation package not loaded" |
+| Kamelet file contains malformed YAML | "Invalid Kamelet file: {name}" |
 
 ---
 
 ### generateOrchestrationCode
 
-**URI**: `codegen://generateOrchestrationCode`
+**URI**: `generateOrchestrationCode` (or `<namespace>/generateOrchestrationCode` if a namespace is configured)
 
 **Description**: "Returns the orchestration template for code generation"
 
@@ -138,21 +139,20 @@ spec:
 
 ## Tool Registration Schema
 
-Tools are registered with Wanaku using the following structure:
+Tools are registered with Wanaku using the Wanaku SDK's `ToolReference` format. Each tool includes:
 
-```json
-{
-  "name": "searchServicesTool",
-  "description": "Searches for services to perform the tasks",
-  "uri": "codegen://searchServicesTool",
-  "type": "codegen",
-  "namespace": "ai.wanaku.codegen",
-  "inputSchema": {
-    "type": "object",
-    "properties": {},
-    "required": []
-  }
-}
+- **name**: The tool identifier (e.g., "searchServicesTool")
+- **description**: Human-readable description of what the tool does
+- **inputSchema**: JSON Schema defining the tool's parameters
+- **namespace** (optional): Grouping namespace for the tool
+
+Example registration for `searchServicesTool`:
+
+```
+name: searchServicesTool
+description: Searches for services to perform the tasks
+namespace: ai.wanaku.codegen (if namespace is set in config.properties)
+inputSchema: {} (no parameters required)
 ```
 
 ## gRPC Message Reference
@@ -182,16 +182,16 @@ message ToolInvokeReply {
 ```
 Agent
   │
-  ▼ ToolInvokeRequest(uri="codegen://searchServicesTool")
+  ▼ ToolInvokeRequest(uri="searchServicesTool")
   │
 Wanaku Router
   │
   ▼ Route to CCE based on tool registration
   │
-CCE (CodeGenToolService)
+CCE (CodeGenToolInvokerService)
   │
-  ├── Parse URI to extract tool name
-  ├── Dispatch to appropriate handler
+  ├── Parse URI to identify tool
+  ├── Dispatch to appropriate handler (SearchServicesTool, ReadKameletTool, or GenerateOrchestrationTool)
   ├── Read from extracted package resources
-  └── Return ToolInvokeReply
+  └── Return ToolInvokeReply(content=result)
 ```

--- a/specs/001-codegen-support-tools/quickstart.md
+++ b/specs/001-codegen-support-tools/quickstart.md
@@ -58,13 +58,13 @@ EOF
 
 ```bash
 cd code-gen-package
-tar -cvjf ../code-gen-package.tar.bz ..
+tar -cjf ../code-gen-package.tar.bz2 config.properties kamelets/ templates/
 cd ..
 ```
 
 ### 3. Upload to Data Store
 
-Upload `code-gen-package.tar.bz` to Wanaku data store with name `code-gen-package.tar.bz`.
+Upload `code-gen-package.tar.bz2` to Wanaku data store.
 
 ## Running CCE with Code Generation Tools
 
@@ -76,7 +76,7 @@ java -jar camel-code-execution-engine-app.jar \
   --client-id your-client-id \
   --client-secret your-client-secret \
   --data-dir /tmp/cce \
-  --codegen-package datastore://code-gen-package.tar.bz
+  --codegen-package datastore-archive://code-gen-package.tar.bz2
 ```
 
 ### Docker
@@ -86,43 +86,22 @@ docker run -it \
   -e REGISTRATION_URL=http://wanaku:8080 \
   -e CLIENT_ID=your-client-id \
   -e CLIENT_SECRET=your-client-secret \
-  -e CODEGEN_PACKAGE=datastore://code-gen-package.tar.bz \
-  -v /tmp/cce:/data \
+  -e CODEGEN_PACKAGE=datastore-archive://code-gen-package.tar.bz2 \
+  -v /tmp/cee:/data \
   camel-code-execution-engine:latest
 ```
 
 ## Verifying Tool Registration
 
-After CCE starts, verify tools are registered:
+After CCE starts, verify tools are registered by checking the service logs. You should see messages indicating successful tool registration:
 
-```bash
-# List registered tools (via Wanaku API)
-curl http://localhost:8080/api/v1/tools | jq '.[] | select(.type == "codegen")'
+```
+INFO  Tool registered: searchServicesTool
+INFO  Tool registered: readKamelet  
+INFO  Tool registered: generateOrchestrationCode
 ```
 
-Expected output:
-```json
-[
-  {
-    "name": "searchServicesTool",
-    "description": "Searches for available services to build integrations",
-    "uri": "codegen://searchServicesTool",
-    "type": "codegen"
-  },
-  {
-    "name": "readKamelet",
-    "description": "Reads the content of a Kamelet by name",
-    "uri": "codegen://readKamelet",
-    "type": "codegen"
-  },
-  {
-    "name": "generateOrchestrationCode",
-    "description": "Returns the orchestration template for code generation",
-    "uri": "codegen://generateOrchestrationCode",
-    "type": "codegen"
-  }
-]
-```
+You can also query the Wanaku discovery service to list available tools (exact endpoint depends on your Wanaku configuration).
 
 ## Using the Tools
 
@@ -130,7 +109,7 @@ Expected output:
 
 ```bash
 grpcurl -plaintext -d '{
-  "uri": "codegen://searchServicesTool"
+  "uri": "searchServicesTool"
 }' localhost:9190 wanaku.capabilities.ToolInvoker/InvokeTool
 ```
 
@@ -138,7 +117,7 @@ grpcurl -plaintext -d '{
 
 ```bash
 grpcurl -plaintext -d '{
-  "uri": "codegen://readKamelet",
+  "uri": "readKamelet",
   "arguments": {"name": "http-source"}
 }' localhost:9190 wanaku.capabilities.ToolInvoker/InvokeTool
 ```
@@ -147,9 +126,11 @@ grpcurl -plaintext -d '{
 
 ```bash
 grpcurl -plaintext -d '{
-  "uri": "codegen://generateOrchestrationCode"
+  "uri": "generateOrchestrationCode"
 }' localhost:9190 wanaku.capabilities.ToolInvoker/InvokeTool
 ```
+
+**Note**: If you configured a namespace in `config.properties`, prefix the tool names with the namespace (e.g., `ai.wanaku.codegen/searchServicesTool`).
 
 ## Troubleshooting
 

--- a/specs/001-codegen-support-tools/spec.md
+++ b/specs/001-codegen-support-tools/spec.md
@@ -66,8 +66,8 @@ The CCE downloads a code generation package (tar.bz2 archive) from the Wanaku da
 
 **Acceptance Scenarios**:
 
-1. **Given** a datastore URI `datastore://code-gen-package.tar.bz`, **When** the service completes registration, **Then** the archive is downloaded and extracted to the data directory.
-2. **Given** the datastore is unavailable, **When** download is attempted, **Then** the system logs an error and continues without code generation tools.
+1. **Given** a datastore URI `datastore-archive://code-gen-package.tar.bz2`, **When** the service completes registration, **Then** the archive is downloaded and extracted to the data directory.
+2. **Given** the datastore is unavailable, **When** download is attempted, **Then** the system logs an error and skips tool registration (the service starts normally but without code generation tools available).
 3. **Given** the archive is successfully extracted, **When** the tools are registered, **Then** they can access the properties file, kamelets directory, and templates directory.
 
 ---


### PR DESCRIPTION
## Summary

- Fixed incorrect URI schemes (`datastore://` → `datastore-archive://`) to match the actual implementation
- Fixed wrong file extension (`.tar.bz` → `.tar.bz2`) throughout all docs
- Replaced fictional `codegen://` URI scheme with the actual `namespace/toolName` pattern
- Fixed tar archive command in quickstart to produce correct flat structure
- Removed contradictory NOTE claiming MCP tools are "not yet functional"
- Removed nonexistent `datastore://` scheme from URI table
- Updated service class name to match implementation (`CodeGenToolInvokerService`)
- Replaced fictional JSON API response with realistic log-based verification guidance

## Test plan

- [ ] Verify documentation accuracy against source code
- [ ] Confirm URI schemes match `CamelEngineMain.java` help text
- [ ] Confirm tar archive structure matches `TarBz2Downloader` expectations