### PR TITLE
ci: align CI workflows with Wanaku codebase conventions

### DIFF
--- a/.github/workflows/depsreview.yaml
+++ b/.github/workflows/depsreview.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.8.2
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -17,9 +17,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Determine SDK ref
+        id: sdk-ref
+        run: |
+          BRANCH="${GITHUB_REF_NAME}"
+          if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+            echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+          else
+            echo "ref=main" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -27,18 +36,18 @@ jobs:
       - name: Checkout and build dependencies
         run: |
           cd ..
-          git clone https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
+          git clone -b ${{ steps.sdk-ref.outputs.ref }} https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
           cd wanaku-capabilities-java-sdk
-          mvn -DskipTests -DskipTests -B install --file pom.xml
+          mvn -DskipTests -B install --file pom.xml
           cd ${{ github.workspace }}
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
+        run: mvn -B install --file pom.xml
       - name: Set arch
         id: arch
         run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -52,7 +61,7 @@ jobs:
 
       - name: Run JReleaser (Linux)
         if: matrix.os == 'ubuntu-latest' && github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # v2.5.0
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -66,7 +75,7 @@ jobs:
 
       - name: JReleaser release output
         if: matrix.os == 'ubuntu-latest' && github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release-linux
           path: |
@@ -77,10 +86,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
         - main
+        - '[0-9]*.[0-9]*.x'
     tags:
       - v*
     paths-ignore:
@@ -27,28 +28,48 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
         cache: maven
+    - name: Determine SDK ref
+      id: sdk-ref
+      run: |
+        BRANCH="${GITHUB_REF_NAME}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
     - name: Checkout and build dependencies
       run: |
         cd ..
-        git clone https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
+        git clone -b ${{ steps.sdk-ref.outputs.ref }} https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
         cd wanaku-capabilities-java-sdk
-        mvn -DskipTests -DskipTests -B install --file pom.xml
+        mvn -DskipTests -B install --file pom.xml
         cd ${{ github.workspace }}
     - name: Build with Maven
       run: mvn -B clean package --file pom.xml
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: test-reports-${{ matrix.os }}
+        path: 'target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore
     - name: Set arch
       id: arch
       run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
     - name: Login to Container Registry
       if: github.repository == 'wanaku-ai/camel-code-execution-engine'
-      uses: docker/login-action@v3
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
       with:
         registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
@@ -64,10 +85,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -7,11 +7,12 @@ on:
     paths:
       - "docs/**/*.md"
       - "*.md"
+      - "examples/**/README.md"
       - ".markdownlint-cli2.yaml"
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25 # v24.0.0

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - '[0-9]*.[0-9]*.x'
     paths-ignore:
       - .github/**
       - docs/**
@@ -31,9 +32,19 @@ jobs:
       fail-fast: true
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Determine SDK ref
+      id: sdk-ref
+      shell: bash
+      run: |
+        BRANCH="${{ github.base_ref }}"
+        if git ls-remote --heads https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git "$BRANCH" | grep -q .; then
+          echo "ref=$BRANCH" >> $GITHUB_OUTPUT
+        else
+          echo "ref=main" >> $GITHUB_OUTPUT
+        fi
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -41,9 +52,20 @@ jobs:
     - name: Checkout and build dependencies
       run: |
         cd ..
-        git clone https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
+        git clone -b ${{ steps.sdk-ref.outputs.ref }} https://github.com/wanaku-ai/wanaku-capabilities-java-sdk.git
         cd wanaku-capabilities-java-sdk
         mvn -DskipTests -B install --file pom.xml
         cd ${{ github.workspace }}
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B install --file pom.xml
+    - name: Generate Test Reports
+      if: always()
+      run: mvn -B --no-transfer-progress surefire-report:report-only surefire-report:failsafe-report-only -Daggregate=true
+    - name: Upload Test Reports
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: test-reports-${{ matrix.os }}
+        path: 'target/reports/'
+        retention-days: 14
+        if-no-files-found: ignore

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -18,12 +18,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: camel-code-execution-engine-${{ github.event.inputs.currentDevelopmentVersion }}
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -35,7 +35,7 @@ jobs:
         run: echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
@@ -51,10 +51,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Login to Container Registry
         if: github.repository == 'wanaku-ai/camel-code-execution-engine'
-        uses: docker/login-action@v3
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       nextDevelopmentVersion:
         description: 'The next development version'
         required: true
+      releaseBranch:
+        description: 'The release branch (e.g., 0.1.x)'
+        required: true
 
 jobs:
   release:
@@ -19,14 +22,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.releaseBranch }}
 
       # Configure build steps as you'd normally do
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 21
           distribution: 'zulu'
@@ -36,12 +40,14 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-          mvn -B --file pom.xml -Dtag=camel-code-execution-engine-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare release:perform -Dgoals=install
+          mvn -B --file pom.xml -Dtag=camel-code-execution-engine-${{ github.event.inputs.currentDevelopmentVersion }} -DreleaseVersion=${{ github.event.inputs.currentDevelopmentVersion }} -DdevelopmentVersion=${{ github.event.inputs.nextDevelopmentVersion }}-SNAPSHOT release:prepare
+          git push origin HEAD:${{ github.event.inputs.releaseBranch }} camel-code-execution-engine-${{ github.event.inputs.currentDevelopmentVersion }}
+          mvn -B --file pom.xml release:perform -Dgoals=install
 
       # Create a release
 
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5 # v2.5.0
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_PROJECT_VERSION: ${{ github.event.inputs.currentDevelopmentVersion }}
@@ -55,7 +61,7 @@ jobs:
 
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: jreleaser-release
           path: |

--- a/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
@@ -5,16 +5,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import ai.wanaku.capabilities.sdk.maven.GAV;
 import ai.wanaku.capabilities.sdk.maven.WanakuMavenDownloader;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to SHA digests with version comments, matching camel-integration-capability
- Add release branch pattern (`[0-9]*.[0-9]*.x`) to main-build, pr-builds triggers to support branch releases
- Add `releaseBranch` input to release workflow and split `release:prepare`/`release:perform` with explicit push, enabling release-from-branch
- Add SDK branch detection (`Determine SDK ref` step) to main-build, pr-builds, and early-access workflows
- Add test report generation and upload steps to main-build and pr-builds
- Fix duplicate `-DskipTests` flag in SDK build steps
- Use `mvn install` instead of `mvn package` in pr-builds and early-access for consistency

## Test plan

- [ ] Verify main-build triggers on `main` and release branches
- [ ] Verify PR builds trigger on PRs targeting release branches
- [ ] Verify release workflow accepts and uses `releaseBranch` input
- [ ] Verify SDK ref detection falls back to `main` when no matching branch exists