### PR TITLE
chore: remove unused private fields flagged by PMD

### DIFF
--- a/src/main/java/ai/wanaku/code/engine/camel/CamelEngineMain.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/CamelEngineMain.java
@@ -216,7 +216,7 @@ public class CamelEngineMain implements Callable<Integer> {
             final ServerBuilder<?> serverBuilder =
                     Grpc.newServerBuilderForPort(grpcPort, InsecureServerCredentials.create());
             final Server server = serverBuilder
-                    .addService(new CodeExecutorService(servicesHttpClient, dataDirPath, repositories))
+                    .addService(new CodeExecutorService(dataDirPath, repositories))
                     .addService(new CodeGenToolInvokerService(codeGenToolService))
                     .addService(new ProvisionBase(name))
                     .build();

--- a/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/WanakuCamelManager.java
@@ -10,16 +10,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.impl.DefaultCamelContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ai.wanaku.capabilities.sdk.maven.GAV;
 import ai.wanaku.capabilities.sdk.maven.WanakuMavenDownloader;
 import ai.wanaku.capabilities.sdk.runtime.camel.downloader.ResourceType;
 import ai.wanaku.capabilities.sdk.runtime.camel.util.WanakuRoutesLoader;
 
 public class WanakuCamelManager {
-    private static final Logger LOG = LoggerFactory.getLogger(WanakuCamelManager.class);
-
     private final CamelContext context;
     private final String routesPath;
     private List<GAV> gavs = new ArrayList<>();

--- a/src/main/java/ai/wanaku/code/engine/camel/grpc/CodeExecutorService.java
+++ b/src/main/java/ai/wanaku/code/engine/camel/grpc/CodeExecutorService.java
@@ -9,7 +9,6 @@ import org.apache.camel.ProducerTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.grpc.stub.StreamObserver;
-import ai.wanaku.capabilities.sdk.services.ServicesHttpClient;
 import ai.wanaku.code.engine.camel.WanakuCamelManager;
 import ai.wanaku.core.exchange.v1.CodeExecutionReply;
 import ai.wanaku.core.exchange.v1.CodeExecutionRequest;
@@ -21,12 +20,10 @@ import com.google.protobuf.Timestamp;
 public class CodeExecutorService extends CodeExecutorGrpc.CodeExecutorImplBase {
     private static final Logger LOG = LoggerFactory.getLogger(CodeExecutorService.class);
 
-    private final ServicesHttpClient servicesHttpClient;
     private final Path dataDir;
     private final String defaultRepositories;
 
-    public CodeExecutorService(ServicesHttpClient servicesHttpClient, Path dataDir, String defaultRepositories) {
-        this.servicesHttpClient = servicesHttpClient;
+    public CodeExecutorService(Path dataDir, String defaultRepositories) {
         this.dataDir = dataDir;
         this.defaultRepositories = defaultRepositories;
     }


### PR DESCRIPTION
## Summary

- Remove unused `LOG` field and `Logger`/`LoggerFactory` imports from `WanakuCamelManager`
- Remove unused `servicesHttpClient` field and constructor parameter from `CodeExecutorService`, update caller in `CamelEngineMain`

Both were flagged by PMD as `UnusedPrivateField` violations.

## Test plan

- [x] PMD check passes clean
- [x] All 54 unit tests pass